### PR TITLE
Chloe: Add GET (show) endpoint for a single record in RecommendationRequest

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -76,4 +76,15 @@ public class RecommendationRequestController extends ApiController {
 
         return savedRecommendationRequest;
     }
+
+    // Get a single record from the table; use the value passed in as a @RequestParam to do a lookup by id. 
+    // If a matching row is found, return the row as a JSON object, 
+    // otherwise throw an EntityNotFoundException.
+    @GetMapping("")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public RecommendationRequest getById(@RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+        return recommendationRequest;
+    }
 }


### PR DESCRIPTION
- added code in RecommendationRequestController.java for an endpoint GET /api/RecommendationRequest?id=123 that returns the JSON of the database record with id 123 if it exists, or a 404 and the error message if not

- The Swagger-UI is well documented and understandable 

- The endpoint works as expected on localhost.

- The endpoint works as expected when deployed to Dokku.

- There is full test coverage (Jacoco)

- There is full mutation test coverage (Pitest)

Closes #22 