### PR TITLE
Adding PUT endpoint for a single record in RecommendationRequest table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -41,6 +41,7 @@ public class RecommendationRequestController extends ApiController {
     @Autowired
     RecommendationRequestRepository recommendationRequestRepository;
 
+    @Operation(summary = "Get all recommendation requests")
     @GetMapping("/all") // get all records in the table and return as a JSON array
     @PreAuthorize("hasRole('ROLE_USER')")
     public Iterable<RecommendationRequest> allRecommendationRequests() {
@@ -48,6 +49,7 @@ public class RecommendationRequestController extends ApiController {
         return requests;
     }
 
+    @Operation(summary = "Create a new recommendation request")
     @PostMapping("/post") // Use the data in the input parameters to create a new row in the table and return the data as JSON
     public RecommendationRequest postRecommendationRequest(
             @Parameter(name="requesterEmail") @RequestParam String requesterEmail,
@@ -81,6 +83,8 @@ public class RecommendationRequestController extends ApiController {
     // use the value passed in as a @RequestParam to do a lookup by id. 
     // If a matching row is found, update that row with values passed in as a JSON object. 
     // If a matching row is not found, throw an EntityNotFoundException.
+    @Operation(summary = "Update a single recommendation request")
+    @Parameter(name="id", description="the id of the recommendation request to update", required = true)
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("")
     public RecommendationRequest updateRecommendationRequest(

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -76,4 +76,29 @@ public class RecommendationRequestController extends ApiController {
 
         return savedRecommendationRequest;
     }
+
+    // Get a single record from the table; 
+    // use the value passed in as a @RequestParam to do a lookup by id. 
+    // If a matching row is found, update that row with values passed in as a JSON object. 
+    // If a matching row is not found, throw an EntityNotFoundException.
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public RecommendationRequest updateRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id,
+            @RequestBody @Valid RecommendationRequest incoming) {
+
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequest.setRequesterEmail(incoming.getRequesterEmail());
+        recommendationRequest.setProfessorEmail(incoming.getProfessorEmail());
+        recommendationRequest.setExplanation(incoming.getExplanation());
+        recommendationRequest.setDateRequested(incoming.getDateRequested());
+        recommendationRequest.setDateNeeded(incoming.getDateNeeded());
+        recommendationRequest.setDone(incoming.getDone());
+
+        recommendationRequestRepository.save(recommendationRequest);
+
+        return recommendationRequest;
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/RecommendationRequestController.java
@@ -41,6 +41,7 @@ public class RecommendationRequestController extends ApiController {
     @Autowired
     RecommendationRequestRepository recommendationRequestRepository;
 
+
     @Operation(summary = "Get all recommendation requests")
     @GetMapping("/all") // get all records in the table and return as a JSON array
     @PreAuthorize("hasRole('ROLE_USER')")
@@ -78,11 +79,33 @@ public class RecommendationRequestController extends ApiController {
 
         return savedRecommendationRequest;
     }
+    
 
-    // Get a single record from the table; 
-    // use the value passed in as a @RequestParam to do a lookup by id. 
-    // If a matching row is found, update that row with values passed in as a JSON object. 
-    // If a matching row is not found, throw an EntityNotFoundException.
+    @Operation(summary = "Get a single RecommendationRequest by id")
+    @Parameter(name = "id", description = "The id of the RecommendationRequest to retrieve", required = true)
+    @GetMapping("")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    public RecommendationRequest getById(@RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+        return recommendationRequest;
+    }
+
+
+    @Operation(summary= "Delete a Recommendation Request")
+    @Parameter(name="id", description="the id of the recommendation request to delete", required = true)
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRecommendationRequest(
+            @Parameter(name="id") @RequestParam Long id) {
+        RecommendationRequest recommendationRequest = recommendationRequestRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RecommendationRequest.class, id));
+
+        recommendationRequestRepository.delete(recommendationRequest);
+        return genericMessage("RecommendationRequest with id %s deleted".formatted(id));
+    }
+
+
     @Operation(summary = "Update a single recommendation request")
     @Parameter(name="id", description="the id of the recommendation request to update", required = true)
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -105,4 +128,7 @@ public class RecommendationRequestController extends ApiController {
 
         return recommendationRequest;
     }
+
+
+    
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -112,7 +112,6 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
             assertEquals(expectedJson, responseString);
     }
 
-        
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void an_admin_user_can_post_a_new_recommendation_request() throws Exception {
@@ -143,7 +142,107 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
             assertEquals(expectedJson, responseString);
     }
 
+    // Authorization tests for GET /api/RecommendationRequest?id=123 : when record exists, and when it does not exist
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_exists_recreq() throws Exception {
+
+         // arrange
+        LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+
+        RecommendationRequest recommendationRequest = RecommendationRequest.builder()
+                        .requesterEmail("student1@ucsb.edu")
+                        .professorEmail("prof1@ucsb.edu")
+                        .explanation("grad program")
+                        .dateRequested(ldt)
+                        .dateNeeded(ldt.plusDays(5))
+                        .done(false)
+                        .build();
+
+        when(recommendationRequestRepository.findById(123L)).thenReturn(Optional.of(recommendationRequest));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/recommendation-requests?id=123")).andExpect(status().isOk()).andReturn();
+        // assert
+
+        verify(recommendationRequestRepository, times(1)).findById(123L);
+        String expectedJson = mapper.writeValueAsString(recommendationRequest);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+      }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist_recreq() throws Exception {
+
+        // arrange
+        when(recommendationRequestRepository.findById(123L)).thenReturn(Optional.empty());
+
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/recommendation-requests?id=123")).andExpect(status().isNotFound()).andReturn();
+
+        // assert
+
+        verify(recommendationRequestRepository, times(1)).findById(123L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("EntityNotFoundException", json.get("type"));
+        assertEquals("RecommendationRequest with id 123 not found", json.get("message"));
+        }
+
         @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_can_delete_a_recommendation_request() throws Exception {
+                // arrange
+
+                LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+                RecommendationRequest recommendationRequest1 = RecommendationRequest.builder()
+                                .requesterEmail("stud1@ucsb.edu")
+                                .professorEmail("prof1@ucsb.edu")
+                                .explanation("grad program")
+                                .dateRequested(ldt1)
+                                .dateNeeded(ldt1.plusDays(5))
+                                .done(false)
+                                .build();
+
+                when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.of(recommendationRequest1));
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/recommendation-requests?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(15L);
+                verify(recommendationRequestRepository, times(1)).delete(any());
+
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RecommendationRequest with id 15 deleted", json.get("message"));
+        }
+
+        @WithMockUser(roles = { "ADMIN", "USER" })
+        @Test
+        public void admin_tries_to_delete_non_existant_recommendation_request_and_gets_right_error_message()
+                        throws Exception {
+                // arrange
+
+                when(recommendationRequestRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(
+                                delete("/api/recommendation-requests?id=15")
+                                                .with(csrf()))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+                verify(recommendationRequestRepository, times(1)).findById(15L);
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("RecommendationRequest with id 15 not found", json.get("message"));
+        }
+
+                @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_can_edit_an_existing_recommendation_request() throws Exception {
                 // arrange

--- a/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/RecommendationRequestControllerTests.java
@@ -112,6 +112,7 @@ public class RecommendationRequestControllerTests extends ControllerTestCase {
             assertEquals(expectedJson, responseString);
     }
 
+        
     @WithMockUser(roles = { "ADMIN", "USER" })
     @Test
     public void an_admin_user_can_post_a_new_recommendation_request() throws Exception {


### PR DESCRIPTION
- RecommendationRequestController.java has an endpoint PUT /api/RecommendationRequest?id=123 that accepts JSON for a new set of values for the database fields other than id, and updates the values of those fields.

- Swagger-UI endpoints is well documented

- The endpoint works as expected on localhost.

- The endpoint works as expected when deployed to Dokku.

- There is full Jacoco test coverage 

- There is full Pitest mutation test coverage

Closes #23 